### PR TITLE
Correct  AttrDict.getattr exception to be AttributeError not KeyError

### DIFF
--- a/authorize/response_parser.py
+++ b/authorize/response_parser.py
@@ -58,7 +58,10 @@ class AttrDict(dict):
         dict.__init__(self, *args, **kw)
 
     def __getattr__(self, key):
-        return self[key]
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(key)
 
     def __setattr__(self, key, value):
         self[key] = value


### PR DESCRIPTION
Other libs fail when they try to getattr(...) and it throws the wrong exception they weren't listening for.   For instance if you try to save the full_response of the authorize exception to a Mongo database with pymongo.